### PR TITLE
Refactor the subsampling module to unify the behaviour of equilibrium…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,8 +22,13 @@ Changes
   - forward_backward_convergence will use AutoMBAR as backend when `MBAR` is
     selected as the estimator (PR #114).
   - AutoMBAR accepts the `method` argument (PR #114).
+  - Refactor the subsampling module to unify the behaviour of
+    equilibrium_detection and statistical_inefficiency (PR #218).
 
 Enhancements
+  - Add u_nk2series and dhdl2series to convert u_nk and dHdl to series (PR
+    #218).
+  - Add remove_burnin keyword to decorrelate_u_nk and decorrelate_dhdl (PR #218).
   - Add a base class for workflows (PR #188).
   - Add the ABFE workflow (PR #114).
 

--- a/docs/preprocessing/alchemlyb.preprocessing.subsampling.rst
+++ b/docs/preprocessing/alchemlyb.preprocessing.subsampling.rst
@@ -5,10 +5,58 @@ Subsampling
 
 .. automodule:: alchemlyb.preprocessing.subsampling
 
-The functions featured in this module can be used to easily subsample either :ref:`dHdl <dHdl>` or :ref:`u_nk <u_nk>` datasets to give less correlated timeseries.
+The functions featured in this module can be used to easily subsample either
+:ref:`dHdl <dHdl>` or :ref:`u_nk <u_nk>` datasets to give less correlated
+timeseries.
+
+High-level functions
+--------------------
+Two high-level functions
+:func:`~alchemlyb.preprocessing.subsampling.decorrelate_u_nk` and
+:func:`~alchemlyb.preprocessing.subsampling.decorrelate_dhdl` can be used to
+preprocess the :ref:`dHdl <dHdl>` or :ref:`u_nk <u_nk>` in an automatic
+fashion. The following code removes an initial "burnin" period and
+decorrelates the data. ::
+
+    >>> from alchemlyb.parsing.gmx import extract_u_nk, extract_dHdl
+    >>> from alchemlyb.preprocessing.subsampling import (decorrelate_u_nk,
+    >>>     decorrelate_dhdl)
+    >>> bz = load_benzene().data
+    >>> u_nk = extract_u_nk(bz['Coulomb'], T=300)
+    >>> decorrelated_u_nk = decorrelate_u_nk(u_nk, method='dhdl',
+    >>>     remove_burnin=True)
+    >>> dhdl = extract_dHdl(bz['Coulomb'], T=300)
+    >>> decorrelated_dhdl = decorrelate_dhdl(dhdl, remove_burnin=True)
+
+Low-level functions
+--------------------
+To decorrelate the data, in addition to the dataframe that contains the
+:ref:`dHdl <dHdl>` or :ref:`u_nk <u_nk>`, a :mod:`pandas.Series` is needed for
+the autocorrection analysis. The series could be generated with
+:func:`~alchemlyb.preprocessing.subsampling.u_nk2series` or
+:func:`~alchemlyb.preprocessing.subsampling.dhdl2series` and feed into
+:func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency` or
+:func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`. ::
+
+    >>> from alchemlyb.parsing.gmx import extract_u_nk, extract_dHdl
+    >>> from alchemlyb.preprocessing.subsampling import (u_nk2series,
+    >>>     dhdl2series, statistical_inefficiency, equilibrium_detection)
+    >>> bz = load_benzene().data
+    >>> u_nk = extract_u_nk(bz['Coulomb'], T=300)
+    >>> u_nk_series = u_nk2series(u_nk, method='dhdl')
+    >>> decorrelate_u_nk = statistical_inefficiency(u_nk, series=u_nk_series)
+    >>> decorrelate_u_nk = equilibrium_detection(u_nk, series=u_nk_series)
+    >>> dhdl = extract_dHdl(bz['Coulomb'], T=300)
+    >>> dhdl_series = dhdl2series(dhdl)
+    >>> decorrelate_dhdl = statistical_inefficiency(dhdl, series=dhdl_series)
+    >>> decorrelate_dhdl = equilibrium_detection(dhdl, series=dhdl_series)
 
 API Reference
 -------------
+.. autofunction:: alchemlyb.preprocessing.subsampling.decorrelate_u_nk
+.. autofunction:: alchemlyb.preprocessing.subsampling.decorrelate_dhdl
+.. autofunction:: alchemlyb.preprocessing.subsampling.u_nk2series
+.. autofunction:: alchemlyb.preprocessing.subsampling.dhdl2series
 .. autofunction:: alchemlyb.preprocessing.subsampling.slicing
 .. autofunction:: alchemlyb.preprocessing.subsampling.statistical_inefficiency
 .. autofunction:: alchemlyb.preprocessing.subsampling.equilibrium_detection

--- a/docs/workflows/alchemlyb.workflows.ABFE.rst
+++ b/docs/workflows/alchemlyb.workflows.ABFE.rst
@@ -30,7 +30,7 @@ to the following code (The log is configured by logger). ::
     >>> dir = os.path.dirname(load_ABFE()['data']['complex'][0])
     >>> print(dir)
     'alchemtest/gmx/ABFE/complex'
-    >>> workflow = ABFE(units='kcal/mol', software='Gromacs', dir=dir,
+    >>> workflow = ABFE(units='kcal/mol', software='GROMACS', dir=dir,
     >>>                 prefix='dhdl', suffix='xvg', T=298, outdirectory='./')
     >>> workflow.run(skiptime=10, uncorr='dhdl', threshold=50,
     >>>              methods=('MBAR', 'BAR', 'TI'), overlap='O_MBAR.pdf',
@@ -133,7 +133,7 @@ to the data generated at each stage of the analysis. ::
     >>> print(dir)
     'alchemtest/gmx/ABFE/complex'
     >>> # Load the data
-    >>> workflow = ABFE(software='Gromacs', dir=dir,
+    >>> workflow = ABFE(software='GROMACS', dir=dir,
     >>>                 prefix='dhdl', suffix='xvg', T=298, outdirectory='./')
     >>> # Set the unit.
     >>> workflow.update_units('kcal/mol')

--- a/src/alchemlyb/preprocessing/__init__.py
+++ b/src/alchemlyb/preprocessing/__init__.py
@@ -3,7 +3,7 @@ The :mod:`alchemlyb.preprocessing` module includes methods for subsampling and
 preparing data for estimators.
 """
 
-from .subsampling import slicing, decorrelate_dhdl, decorrelate_u_nk
+from .subsampling import slicing, dhdl2series, u_nk2series, decorrelate_dhdl, decorrelate_u_nk
 from .subsampling import statistical_inefficiency
 from .subsampling import equilibrium_detection
 
@@ -12,5 +12,7 @@ __all__ = [
     'statistical_inefficiency',
     'equilibrium_detection',
     'decorrelate_dhdl',
-    'decorrelate_u_nk'
+    'decorrelate_u_nk',
+    'dhdl2series',
+    'u_nk2series'
 ]

--- a/src/alchemlyb/preprocessing/subsampling.py
+++ b/src/alchemlyb/preprocessing/subsampling.py
@@ -1,23 +1,21 @@
 """Functions for subsampling datasets.
 
 """
-import numpy as np
 import pandas as pd
 from pymbar.timeseries import (statisticalInefficiency,
                                detectEquilibration,
                                subsampleCorrelatedData, )
 
 def decorrelate_u_nk(df, method='dhdl', drop_duplicates=True,
-                     sort=True, **kwargs):
+                     sort=True, remove_burnin=False, **kwargs):
     """Subsample a u_nk DataFrame based on the selected method.
-
     The method can be either 'dhdl_all' (obtained as a sum over all energy
     components) or 'dhdl' (obtained as the energy components that are
     changing; default) or 'dE'. In the latter case the energy differences
     dE_{i,i+1} (dE_{i,i-1} for the last lambda) are used.
-
     This is a wrapper function around the function
-    :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`.
+    :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency` or
+    :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
 
     Parameters
     ----------
@@ -29,25 +27,112 @@ def decorrelate_u_nk(df, method='dhdl', drop_duplicates=True,
         Drop the duplicated lines based on time.
     sort : bool
         Sort the Dataframe based on the time column.
+    remove_burnin : bool
+        Whether to perform equilibrium detection (``True``) or just do
+        statistical inefficiency (``False``).
     **kwargs :
         Additional keyword arguments for
-        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`.
-
+        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`
+        or :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
     Returns
     -------
     DataFrame
         `df` subsampled according to selected `method`.
+    Note
+    ----
+    The default of ``True`` for  `drop_duplicates` and `sort` should result in robust decorrelation
+    but can lose data.
 
+
+    .. versionadded:: 0.6.0
+    .. versionchanged:: 1.0.0
+       Add the remove_burnin keyword to allow unequilibrated frames to be removed.
+    """
+    kwargs['drop_duplicates'] = drop_duplicates
+    kwargs['sort'] = sort
+
+    series = u_nk2series(df, method)
+
+    if remove_burnin:
+        return equilibrium_detection(df, series, **kwargs)
+    else:
+        return statistical_inefficiency(df, series, **kwargs)
+
+def decorrelate_dhdl(df, drop_duplicates=True, sort=True,
+                     remove_burnin=False, **kwargs):
+    """Subsample a dhdl DataFrame.
+    This is a wrapper function around the function
+    :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency` and
+    :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
+
+    Parameters
+    ----------
+    df : DataFrame
+        DataFrame to subsample according to the selected method.
+    drop_duplicates : bool
+        Drop the duplicated lines based on time.
+    sort : bool
+        Sort the Dataframe based on the time column.
+    remove_burnin : bool
+        Whether to perform equilibrium detection (``True``) or just do
+        statistical inefficiency (``False``).
+    **kwargs :
+        Additional keyword arguments for
+        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`
+        or :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
+
+    Returns
+    -------
+    DataFrame
+        `df` subsampled.
     Note
     ----
     The default of ``True`` for  `drop_duplicates` and `sort` should result in robust decorrelation
     but can loose data.
 
+
     .. versionadded:: 0.6.0
+    .. versionchanged:: 1.0.0
+       Add the remove_burnin keyword to allow unequilibrated frames to be removed.
     """
+
     kwargs['drop_duplicates'] = drop_duplicates
     kwargs['sort'] = sort
 
+    series = dhdl2series(df)
+
+    if remove_burnin:
+        return equilibrium_detection(df, series, **kwargs)
+    else:
+        return statistical_inefficiency(df, series, **kwargs)
+
+def u_nk2series(df, method='dhdl'):
+    """Convert an u_nk DataFrame into a series based on the selected method
+    for subsampling.
+
+    The method can be either 'dhdl_all' (obtained as a sum over all energy
+    components) or 'dhdl' (obtained as the energy components that are
+    changing; default) or 'dE'. In the latter case the energy differences
+    dE_{i,i+1} (dE_{i,i-1} for the last lambda) are used.
+
+    Parameters
+    ----------
+    df : DataFrame
+        DataFrame to be converted according to the selected method.
+    method : {'dhdl', 'dhdl_all', 'dE'}
+        Method for converting the data.
+
+    Returns
+    -------
+    Series
+        `series` to be used as input for
+        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`
+        or
+        :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
+
+
+    .. versionadded:: 1.0.0
+    """
     # Check if the input is u_nk
     try:
         key = df.index.values[0][1:]
@@ -84,49 +169,36 @@ def decorrelate_u_nk(df, method='dhdl', drop_duplicates=True,
             # for the state that is the last state, take the state-1
         else:
             series = df.iloc[:, index - 1]
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise ValueError(
             'Decorrelation method {} not found.'.format(method))
-    return statistical_inefficiency(df, series, **kwargs)
+    return series
 
-def decorrelate_dhdl(df, drop_duplicates=True, sort=True, **kwargs):
-    """Subsample a dhdl DataFrame.
 
-    This is a wrapper function around the function
-    :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`.
+def dhdl2series(df, method=''):
+    """Convert a dhdl DataFrame to a series for subsampling.
 
     Parameters
     ----------
     df : DataFrame
         DataFrame to subsample according to the selected method.
-    drop_duplicates : bool
-        Drop the duplicated lines based on time.
-    sort : bool
-        Sort the Dataframe based on the time column.
-    **kwargs :
-        Additional keyword arguments for
-        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`.
+    method : string
+        An input mirrored based on u_nk2series, not being used.
 
     Returns
     -------
-    DataFrame
-        `df` subsampled.
-
-    Note
-    ----
-    The default of ``True`` for  `drop_duplicates` and `sort` should result in robust decorrelation
-    but can loose data.
+    Series
+        `series` to be used as input for
+        :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency`
+        or
+        :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
 
 
-    .. versionadded:: 0.6.0
+    .. versionadded:: 1.0.0
     """
-
-    kwargs['drop_duplicates'] = drop_duplicates
-    kwargs['sort'] = sort
-
     series = df.sum(axis=1)
+    return series
 
-    return statistical_inefficiency(df, series, **kwargs)
 
 def _check_multiple_times(df):
     if isinstance(df, pd.Series):
@@ -138,6 +210,121 @@ def _check_multiple_times(df):
 def _check_sorted(df):
     return df.reset_index(0)['time'].is_monotonic_increasing
 
+
+def _drop_duplicates(df, series=None):
+    """Drop the duplication in the ``df`` which could be Dataframe or
+    Series, if series is provided, format the series such that it has the
+    same length as ``df``.
+
+    Parameters
+    ----------
+    df : DataFrame or Series
+        DataFrame or Series where duplication will be dropped.
+    series : Series
+        series to be formatted in the same way as df.
+
+    Returns
+    -------
+    df : DataFrame or Series
+        Formatted DataFrame or Series.
+    series : Series
+        Formatted Series.
+    """
+    if isinstance(df, pd.Series):
+        # remove the duplicate based on time
+        drop_duplicates_series = df.reset_index('time', name=''). \
+            drop_duplicates('time')
+        # Rest the time index
+        lambda_names = ['time', ]
+        lambda_names.extend(drop_duplicates_series.index.names)
+        df = drop_duplicates_series.set_index('time', append=True). \
+            reorder_levels(lambda_names)
+    else:
+        # remove the duplicate based on time
+        drop_duplicates_df = df.reset_index('time').drop_duplicates('time')
+        # Rest the time index
+        lambda_names = ['time', ]
+        lambda_names.extend(drop_duplicates_df.index.names)
+        df = drop_duplicates_df.set_index('time', append=True). \
+            reorder_levels(lambda_names)
+
+    # Do the same withing with the series
+    if series is not None:
+        # remove the duplicate based on time
+        drop_duplicates_series = series.reset_index('time', name=''). \
+            drop_duplicates('time')
+        # Rest the time index
+        lambda_names = ['time', ]
+        lambda_names.extend(drop_duplicates_series.index.names)
+        series = drop_duplicates_series.set_index('time', append=True). \
+            reorder_levels(lambda_names)
+    return df, series
+
+def _sort_by_time(df, series=None):
+    """Sort the ``df`` by time which could be Dataframe or
+    Series, if series is provided, sort the series as well.
+
+    Parameters
+    ----------
+    df : DataFrame or Series
+        DataFrame or Series to be sorted by time.
+    series : Series
+        series to be sorted by time.
+
+    Returns
+    -------
+    df : DataFrame or Series
+        Formatted DataFrame or Series.
+    series : Series
+        Formatted Series.
+    """
+    df = df.sort_index(level='time')
+
+    if series is not None:
+        series = series.sort_index(level='time')
+    return df, series
+
+def _prepare_input(df, series, drop_duplicates, sort):
+    """Prepare and check the input to be used for statistical_inefficiency or equilibrium_detection.
+
+    Parameters
+    ----------
+    df : DataFrame or Series
+        DataFrame or Series to be Prepared and checked.
+    series : Series
+        series to be Prepared and checked.
+
+    Returns
+    -------
+    df : DataFrame or Series
+        Formatted DataFrame or Series.
+    series : Series
+        Formatted Series.
+    """
+    if _check_multiple_times(df):
+        if drop_duplicates:
+            df, series = _drop_duplicates(df, series)
+        else:
+            raise KeyError(
+                "Duplicate time values found; statistical inefficiency "
+                "only works on a single, contiguous, "
+                "and sorted timeseries.")
+
+    if not _check_sorted(df):
+        if sort:
+            df, series = _sort_by_time(df, series)
+        else:
+            raise KeyError(
+                "Statistical inefficiency only works as expected if "
+                "values are sorted by time, increasing.")
+
+    if series is not None:
+        if (len(series) != len(df) or
+                not all(
+                    series.reset_index()['time'] == df.reset_index()['time'])):
+            raise ValueError(
+                "series and data must be sampled at the same times")
+    return df, series
 
 def slicing(df, lower=None, upper=None, step=None, force=False):
     """Subsample a DataFrame using simple slicing.
@@ -176,8 +363,10 @@ def slicing(df, lower=None, upper=None, step=None, force=False):
 
     return df
 
-def statistical_inefficiency(df, series=None, lower=None, upper=None, step=None,
-                             conservative=True, drop_duplicates=False, sort=False):
+
+def statistical_inefficiency(df, series=None, lower=None, upper=None,
+                             step=None, conservative=True,
+                             drop_duplicates=False, sort=False):
     """Subsample a DataFrame based on the calculated statistical inefficiency
     of a timeseries.
 
@@ -241,70 +430,21 @@ def statistical_inefficiency(df, series=None, lower=None, upper=None, step=None,
        inefficiency was _rounded_ (instead of ``ceil()``) and thus one could
        end up with correlated data.
 
-    .. versionchanged:: 0.7.0
+    .. versionchanged:: 1.0.0
        Fixed a bug that would effectively ignore the ``lower`` and ``step``
        keywords when returning the subsampled DataFrame object. See
        `issue #198 <https://github.com/alchemistry/alchemlyb/issues/198>`_ for 
        more details.
 
     """
-    if _check_multiple_times(df):
-        if drop_duplicates:
-            if isinstance(df, pd.Series):
-                # remove the duplicate based on time
-                drop_duplicates_series = df.reset_index('time', name='').\
-                    drop_duplicates('time')
-                # Rest the time index
-                lambda_names = ['time',]
-                lambda_names.extend(drop_duplicates_series.index.names)
-                df = drop_duplicates_series.set_index('time', append=True).\
-                    reorder_levels(lambda_names)
-            else:
-                # remove the duplicate based on time
-                drop_duplicates_df = df.reset_index('time').drop_duplicates('time')
-                # Rest the time index
-                lambda_names = ['time',]
-                lambda_names.extend(drop_duplicates_df.index.names)
-                df = drop_duplicates_df.set_index('time', append=True).\
-                    reorder_levels(lambda_names)
-
-            # Do the same withing with the series
-            if series is not None:
-                # remove the duplicate based on time
-                drop_duplicates_series = series.reset_index('time', name='').\
-                    drop_duplicates('time')
-                # Rest the time index
-                lambda_names = ['time',]
-                lambda_names.extend(drop_duplicates_series.index.names)
-                series = drop_duplicates_series.set_index('time', append=True).\
-                    reorder_levels(lambda_names)
-
-        else:
-            raise KeyError("Duplicate time values found; statistical inefficiency "
-                           "only works on a single, contiguous, "
-                           "and sorted timeseries.")
-
-    if not _check_sorted(df):
-        if sort:
-            df = df.sort_index(level='time')
-
-            if series is not None:
-                series = series.sort_index(level='time')
-        else:
-            raise KeyError("Statistical inefficiency only works as expected if "
-                           "values are sorted by time, increasing.")
+    df, series = _prepare_input(df, series, drop_duplicates, sort)
 
     if series is not None:
-    
-        if (len(series) != len(df) or
-            not all(series.reset_index()['time'] == df.reset_index()['time'])):
-            raise ValueError("series and data must be sampled at the same times")
-               
         series = slicing(series, lower=lower, upper=upper, step=step)
         df = slicing(df, lower=lower, upper=upper, step=step)
 
         # calculate statistical inefficiency of series (could use fft=True but needs test)
-        statinef  = statisticalInefficiency(series, fast=False)
+        statinef = statisticalInefficiency(series, fast=False)
 
         # use the subsampleCorrelatedData function to get the subsample index
         indices = subsampleCorrelatedData(series, g=statinef,
@@ -316,7 +456,8 @@ def statistical_inefficiency(df, series=None, lower=None, upper=None, step=None,
     return df
 
 
-def equilibrium_detection(df, series=None, lower=None, upper=None, step=None):
+def equilibrium_detection(df, series=None, lower=None, upper=None, step=None,
+                          drop_duplicates=False, sort=False):
     """Subsample a DataFrame using automated equilibrium detection on a timeseries.
 
     If `series` is ``None``, then this function will behave the same as
@@ -335,6 +476,10 @@ def equilibrium_detection(df, series=None, lower=None, upper=None, step=None):
         Upper bound to pre-slice `series` to (inclusive).
     step : int
         Step between `series` items to pre-slice by.
+    drop_duplicates : bool
+        Drop the duplicated lines based on time.
+    sort : bool
+        Sort the Dataframe based on the time column.
 
     Returns
     -------
@@ -344,30 +489,29 @@ def equilibrium_detection(df, series=None, lower=None, upper=None, step=None):
     See Also
     --------
     pymbar.timeseries.detectEquilibration : detailed background
+    pymbar.timeseries.subsampleCorrelatedData : used for subsampling
+
+
+    .. versionchanged:: 1.0.0
+       Add the drop_duplicates and sort keyword to unify the behaviour between
+    :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency` or
+    :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection`.
 
     """
-    if _check_multiple_times(df):
-        raise KeyError("Duplicate time values found; equilibrium detection "
-                       "is only meaningful for a single, contiguous, "
-                       "and sorted timeseries.")
-
-    if not _check_sorted(df):
-        raise KeyError("Equilibrium detection only works as expected if "
-                       "values are sorted by time, increasing.")
+    df, series = _prepare_input(df, series, drop_duplicates, sort)
 
     if series is not None:
         series = slicing(series, lower=lower, upper=upper, step=step)
+        df = slicing(df, lower=lower, upper=upper, step=step)
 
         # calculate statistical inefficiency of series, with equilibrium detection
-        t, statinef, Neff_max  = detectEquilibration(series.values)
+        t, statinef, Neff_max = detectEquilibration(series.values)
 
-        # we round up
-        statinef = int(np.rint(statinef))
+        series_equil = series[t:]
+        df_equil = df[t:]
 
-        # subsample according to statistical inefficiency
-        series = series.iloc[t::statinef]
-
-        df = df.loc[series.index]
+        indices = subsampleCorrelatedData(series_equil, g=statinef)
+        df = df_equil.iloc[indices]
     else:
         df = slicing(df, lower=lower, upper=upper, step=step)
 

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -428,6 +428,16 @@ def test_decorrelate_u_nk_single_l(gmx_benzene_u_nk_fixture, method, size):
                                 drop_duplicates=True,
                                 sort=True)) == size
 
+def test_decorrelate_u_nk_burnin(gmx_benzene_u_nk_fixture):
+    assert len(decorrelate_u_nk(gmx_benzene_u_nk_fixture, method='dhdl',
+                                drop_duplicates=True,
+                                sort=True, remove_burnin=True)) == 2743
+
+def test_decorrelate_dhdl_burnin(gmx_benzene_dHdl_fixture):
+    assert len(decorrelate_dhdl(gmx_benzene_dHdl_fixture,
+                                drop_duplicates=True,
+                                sort=True, remove_burnin=True)) == 2848
+
 @pytest.mark.parametrize(('method', 'size'), [('dhdl', 501),
                                               ('dhdl_all', 1001),
                                               ('dE', 334)])

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -143,7 +143,7 @@ class ABFE(WorkflowBase):
                 u_nk_list[x].reset_index('time').index.values[0]))
 
         self.file_list = [self.file_list[i] for i in index_list]
-        self.logger.info("Sorted file list: \n %s", '\n'.join(self.file_list))
+        self.logger.info("Sorted file list: \n%s", '\n'.join(self.file_list))
         self.u_nk_list = [u_nk_list[i] for i in index_list]
         self.dHdl_list = [dHdl_list[i] for i in index_list]
         self.u_nk_sample_list = None
@@ -274,7 +274,7 @@ class ABFE(WorkflowBase):
                 # Find the starting frame
 
                 u_nk = u_nk[u_nk.index.get_level_values('time') >= skiptime]
-                subsample = decorrelate_u_nk(u_nk, uncorr)
+                subsample = decorrelate_u_nk(u_nk, uncorr, remove_burnin=True)
 
                 if len(subsample) < threshold:
                     self.logger.warning(f'Number of u_nk {len(subsample)} '
@@ -293,7 +293,7 @@ class ABFE(WorkflowBase):
             self.dHdl_sample_list = []
             for index, dHdl in enumerate(self.dHdl_list):
                 dHdl = dHdl[dHdl.index.get_level_values('time') >= skiptime]
-                subsample = decorrelate_dhdl(dHdl)
+                subsample = decorrelate_dhdl(dHdl, remove_burnin=True)
                 if len(subsample) < threshold:
                     self.logger.warning(f'Number of dHdl {len(subsample)} for '
                                         f'state {index} is less than the '


### PR DESCRIPTION
…_detection and statistical_inefficiency (#218)

* Add the keyword remove_burnin to the high-level function decorrelate_u_nk and decorrelate_dhdl to use equilibrium_detection instead of statistical_inefficiency.
* Extract the function u_nk2series and dhdl2series to make series from dataframe
* Extract the function _drop_duplicates, _sort_by_time and _prepare_input to clean the data before passing to equilibrium_detection and statistical_inefficiency
* Unify the behaviour of equilibrium_detection and statistical_inefficiency in terms of preprocessing and  checking the data.
* add docs for new functions
* update tests and add tests
* update CHANGELOG for 1.0

Co-authored-by: Zhiyi Wu <zwu@exscientia.co.uk>
Co-authored-by: Oliver Beckstein <orbeckst@gmail.com>