### PR TITLE
AMBER parser now uses "ntpr" information properly (issue #221) (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ src/alchemlyb.egg-info/
 __pycache__
 .coverage.*
 *~
+dist/
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -46,3 +46,4 @@ Chronological list of authors
 2022
   - Irfan Alibay (@IAlibay)
   - Pascal Merz (@ptmerz)
+  - Domenico Marson (@DrDomenicoMarson)

--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Enhancements
 
 Fixes
   - documented conda installation (available since 0.6.0) (#192)
+  - AMBER parsers now use 'ntpr' information to read time properly (#221)
 
 
 07/22/2022 xiki-tempula, IAlibay, dotsdl, orbeckst, ptmerz

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -7,7 +7,6 @@ Most of the file parsing parts are inherited from
 
 """
 
-import os
 import re
 import logging
 
@@ -32,8 +31,7 @@ def convert_to_pandas(file_datum):
     for frame_index, frame_dhdl in enumerate(file_datum.gradients):
         data_dic["dHdl"].append(frame_dhdl)
         data_dic["lambdas"].append(file_datum.clambda)
-        # here we need to convert dt to ps unit from ns
-        frame_time = file_datum.t0 + (frame_index + 1) * file_datum.dt * 1000
+        frame_time = file_datum.t0 + (frame_index + 1) * file_datum.dt * file_datum.ntpr
         data_dic["time"].append(frame_time)
     df = pd.DataFrame(data_dic["dHdl"], columns=["dHdl"],
                       index=pd.Index(data_dic["time"], name='time', dtype='Float64'))
@@ -165,7 +163,7 @@ class SectionParser(object):
 class FEData(object):
     """A simple struct container to collect data from individual files."""
 
-    __slots__ = ['clambda', 't0', 'dt', 'T', 'gradients',
+    __slots__ = ['clambda', 't0', 'dt', 'T', 'ntpr', 'gradients',
                  'component_gradients', 'mbar_energies',
                  'have_mbar', 'mbar_lambdas', 'mbar_lambda_idx']
 
@@ -174,6 +172,7 @@ class FEData(object):
         self.t0 = -1.0
         self.dt = -1.0
         self.T = -1.0
+        self.ntpr = -1
         self.gradients = []
         self.component_gradients = []
         self.mbar_energies = []
@@ -250,6 +249,7 @@ def file_validation(outfile):
     file_datum.clambda = clambda
     file_datum.t0 = t0
     file_datum.dt = dt
+    file_datum.ntpr = ntpr
     file_datum.T = T
     file_datum.have_mbar = have_mbar
     return file_datum
@@ -307,7 +307,7 @@ def extract_u_nk(outfile, T):
             logger.warning('%i MBAR energ%s > 0.0 kcal/mol',
                            high_E_cnt, 'ies are' if high_E_cnt > 1 else 'y is')
 
-        time = [file_datum.t0 + (frame_index + 1) * file_datum.dt * 1000
+        time = [file_datum.t0 + (frame_index + 1) * file_datum.dt * file_datum.ntpr 
                 for frame_index in range(len(file_datum.mbar_energies[0]))]
 
     return pd.DataFrame(file_datum.mbar_energies,
@@ -350,7 +350,6 @@ def extract_dHdl(outfile, T):
         nenav = 0
         old_nstep = -1
         old_comp_nstep = -1
-        high_E_cnt = 0
         in_comps = False
         for line in secp:
             if 'DV/DL, AVERAGES OVER' in line:

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -2,6 +2,7 @@
 
 """
 import pytest
+from numpy.testing import assert_allclose
 
 from alchemlyb.parsing.amber import extract_dHdl
 from alchemlyb.parsing.amber import extract_u_nk
@@ -13,10 +14,60 @@ from alchemtest.amber import load_bace_example
 from alchemtest.amber import load_bace_improper
 
 
-@pytest.fixture(scope="module",
-                params=[filename for filename in load_invalidfiles()['data'][0]])
-def invalid_file(request):
+@pytest.fixture(
+    name="invalid_file", scope="module",
+    params=list(load_invalidfiles()['data'][0]))
+def fixture_invalid_file(request):
+    """
+    Set 'invalid_file' for the subsequent tests, 
+    returning each file in load_invalidfiles
+    """
     return request.param
+
+
+@pytest.fixture(name="single_u_nk", scope="module")
+def fixture_single_u_nk():
+    """return a single file to check u_unk parsing"""
+    return load_bace_example().data['solvated']['vdw'][0]
+
+
+@pytest.fixture(name="single_dHdl", scope="module")
+def fixture_single_dHdl():
+    """return a single file to check u_unk parsing"""
+    return load_simplesolvated().data['charge'][0]
+
+
+def test_any_none():
+    """Test the any None function to ensure if the None value will be caught"""
+    None_value_result = [150000, None, None, None, None, None, None, None, None]
+    assert any_none(None_value_result) is True
+
+
+def test_invalidfiles(invalid_file):
+    """
+    Test the file validation function to ensure the 
+    function returning False if the file is invalid
+    """
+    assert file_validation(invalid_file) is False
+
+
+def test_dHdl_invalidfiles(invalid_file):
+    """Test if we catch possible parsing errors in invalid files"""
+    assert extract_dHdl(invalid_file, T=300) is None
+
+
+def test_dHdl_time_reading(single_dHdl, first_time=22.0, last_time=1020.0):
+    """Test if time information is read correctly when extracting dHdl"""
+    dHdl = extract_dHdl(single_dHdl, T=300)
+    assert_allclose(dHdl.index.values[0][0], first_time)
+    assert_allclose(dHdl.index.values[-1][0], last_time)
+
+
+def test_u_nk_time_reading(single_u_nk, first_time=22.0, last_time=1020.0):
+    """Test if time information is read correctly when extracting u_nk"""
+    u_nk = extract_u_nk(single_u_nk, T=300)
+    assert_allclose(u_nk.index.values[0][0], first_time)
+    assert_allclose(u_nk.index.values[-1][0], last_time)
 
 
 @pytest.mark.parametrize("filename",
@@ -54,24 +105,6 @@ def test_u_nk_improper(improper_filename,
     """Test the u_nk has the correct form when extracted from files"""
     try:
         u_nk = extract_u_nk(improper_filename, T=300)
-
         assert u_nk.index.names == names
-
-    except:
+    except Exception:
         assert '0.5626' in improper_filename
-
-
-def test_invalidfiles(invalid_file):
-    """Test the file validation function to ensure the function returning False if the file is invalid
-    """
-    assert file_validation(invalid_file) == False
-
-
-def test_dHdl_invalidfiles(invalid_file):
-    assert extract_dHdl(invalid_file, T=300) is None
-
-
-def test_any_none():
-    """Test the any None function to ensure if the None value will be caught"""
-    None_value_result = [150000, None, None, None, None, None, None, None, None]
-    assert any_none(None_value_result) == True


### PR DESCRIPTION
Here is a smaller PR in which just the parsing of time information in AMBER parsers is fixed, now both functions use ntpr information properly as for issue #221.

PS: I left also some minor changes (like removing an unused import os) because I missed them while rolling back to the previous version, but are really really small and changes.

PS2: the commit history here is a bit messy, but looking at the files changed it should be clear the changes are minimum, and commits will be more structured in the future.

NB: the alchemtest PR I recently made is needed for this fix to succeed properly.